### PR TITLE
#28 import current directory module for test

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,3 +1,6 @@
+import sys
+import os
+sys.path.append(os.getcwd())
 from psikit import Psikit
 from psikit import Sapt
 import rdkit


### PR DESCRIPTION
Changed test_init.py. Current test code imports psikit from current directly. And all test was passed on travis ci with same code.
https://travis-ci.org/iwatobipen/psikit_tdd/builds/569354476
Following document recommend make virtual env and install package with pip install -e .
It will solve the issue.
https://docs.pytest.org/en/latest/goodpractices.html
